### PR TITLE
fix: rename CFLAGS to CFLAGS_SAML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ LUAJIT_DIR=/usr/local/openresty/luajit
 XMLSEC_VER=1.2.28
 
 CC=gcc
-CFLAGS=-g -fPIC -O2 -fcommon
+CFLAGS_SAML=-g -fPIC -O2 -fcommon
 XMLSEC1_CFLAGS=-D__XMLSEC_FUNCTION__=__func__ -DXMLSEC_NO_SIZE_T -DXMLSEC_NO_GOST=1 -DXMLSEC_NO_GOST2012=1 -DXMLSEC_NO_CRYPTO_DYNAMIC_LOADING=1 -Ixmlsec1-$(XMLSEC_VER)/include/ -I/usr/include/libxml2 -DXMLSEC_CRYPTO_OPENSSL=1
-CFLAGS_ALL=$(CFLAGS) -Wall -Werror -std=c99 $(XMLSEC1_CFLAGS)
+CFLAGS_ALL=$(CFLAGS_SAML) -Wall -Werror -std=c99 $(XMLSEC1_CFLAGS)
 LIBFLAG=-shared
 LDFLAGS=-g -O2
 XMLSEC1_STATIC_LIBS=xmlsec1-$(XMLSEC_VER)/./src/openssl/.libs/libxmlsec1-openssl.a xmlsec1-$(XMLSEC_VER)/./src/.libs/libxmlsec1.a


### PR DESCRIPTION
In luarocks make, it would override the CFLAGS, which makes the compilation fails with gcc 10 on alpine.