### PR TITLE
feat: release v0.2.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LDFLAGS_ALL = $(LIBFLAG) $(LDFLAGS) $(XMLSEC1_LDFLAGS)
 build: $(XMLSEC1_STATIC_LIBS) saml.so
 
 $(XMLSEC1_STATIC_LIBS):
-	wget --no-check-certificate https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-$(XMLSEC_VER).tar.gz
+	wget https://github.com/api7/xmlsec-fork/releases/download/$(XMLSEC_VER)/xmlsec1-$(XMLSEC_VER).tar.gz
 	tar zxf xmlsec1-$(XMLSEC_VER).tar.gz
 	cd xmlsec1-$(XMLSEC_VER); CFLAGS="-std=c99" ./configure --with-openssl=$(OPENSSL_DIR)/ --with-pic --disable-crypto-dl --disable-apps-crypto-dl; make
 

--- a/rockspec/lua-resty-saml-0.2.3-0.rockspec
+++ b/rockspec/lua-resty-saml-0.2.3-0.rockspec
@@ -1,0 +1,38 @@
+package = "lua-resty-saml"
+version = "0.2.3-0"
+source = {
+    url = "git://github.com/api7/lua-resty-saml",
+    tag = "v0.2.3"
+}
+
+description = {
+    summary = "SAML 2.0 auth lib for Nginx + Lua",
+    homepage = "https://github.com/api7/lua-resty-saml",
+    license = "Apache License 2.0",
+}
+
+dependencies = {
+    "api7-lua-resty-http = 0.2.0",
+    "lua-resty-jit-uuid = 0.0.7",
+    "lua-resty-cookie = 0.1.0",
+}
+
+build = {
+    type = "make",
+    build_variables = {
+        CFLAGS="$(CFLAGS)",
+        LIBFLAG="$(LIBFLAG)",
+        LUA_LIBDIR="$(LUA_LIBDIR)",
+        LUA_BINDIR="$(LUA_BINDIR)",
+        LUA_INCDIR="$(LUA_INCDIR)",
+        LUA="$(LUA)",
+        OPENSSL_DIR="$(OPENSSL_DIR)",
+    },
+    install_variables = {
+        INST_PREFIX="$(PREFIX)",
+        INST_BINDIR="$(BINDIR)",
+        INST_LIBDIR="$(LIBDIR)",
+        INST_LUADIR="$(LUADIR)",
+        INST_CONFDIR="$(CONFDIR)",
+    },
+}


### PR DESCRIPTION
During CI runs at https://github.com/api7/api7-ee-3-gateway/actions/runs/14161783095/attempts/10?pr=858, 403 errors were frequently encountered, so [the release from the API7 Fork repository](https://github.com/api7/xmlsec-fork/releases/tag/1.2.28) is used instead of the original xmlsec download address.